### PR TITLE
Fix #60: Push Credentials Setup - invalid iOS bundle ID

### DIFF
--- a/powerauth-push-server/src/main/java/io/getlime/push/controller/web/model/form/UploadIosCredentialsForm.java
+++ b/powerauth-push-server/src/main/java/io/getlime/push/controller/web/model/form/UploadIosCredentialsForm.java
@@ -31,7 +31,7 @@ public class UploadIosCredentialsForm {
 
     @NotNull
     @Size(min = 2)
-    @Pattern(flags = { Pattern.Flag.CASE_INSENSITIVE },regexp = "^[a-z][a-z0-9_]*(\\.[a-z0-9_]+)+[0-9a-z_]$")
+    @Pattern(flags = { Pattern.Flag.CASE_INSENSITIVE },regexp = "^[a-z][a-z0-9_-]*(\\.[a-z0-9_-]+)+[0-9a-z_-]$")
     private String bundle;
 
     @NotNull


### PR DESCRIPTION
Relaxed validation regexp to allow '-' character