### PR TITLE
Fix #86: Server hangs on database issue

### DIFF
--- a/powerauth-push-server/src/main/java/io/getlime/push/service/PushMessageSenderService.java
+++ b/powerauth-push-server/src/main/java/io/getlime/push/service/PushMessageSenderService.java
@@ -168,6 +168,8 @@ public class PushMessageSenderService {
                                     }
                                 }
                                 sendResult.getIos().setTotal(sendResult.getIos().getTotal() + 1);
+                            } catch (Throwable t) {
+                                Logger.getLogger(PushMessageSenderService.class.getName()).log(Level.SEVERE, "System error when sending notification: " + t.getMessage(), t);
                             } finally {
                                 phaser.arriveAndDeregister();
                             }
@@ -205,6 +207,8 @@ public class PushMessageSenderService {
                                     }
                                 }
                                 sendResult.getAndroid().setTotal(sendResult.getAndroid().getTotal() + 1);
+                            } catch (Throwable t) {
+                                Logger.getLogger(PushMessageSenderService.class.getName()).log(Level.SEVERE, "System error when sending notification: " + t.getMessage(), t);
                             } finally {
                                 phaser.arriveAndDeregister();
                             }

--- a/powerauth-push-server/src/main/java/io/getlime/push/service/PushMessageSenderService.java
+++ b/powerauth-push-server/src/main/java/io/getlime/push/service/PushMessageSenderService.java
@@ -138,69 +138,75 @@ public class PushMessageSenderService {
                     String platform = device.getPlatform();
                     if (platform.equals(PushDeviceRegistrationEntity.Platform.iOS)) {
                         sendMessageToIos(pushClient.getApnsClient(), pushMessage.getBody(), pushMessage.getAttributes(), device.getPushToken(), pushClient.getAppCredentials().getIosBundle(), (result, contextData) -> {
-                            switch (result) {
-                                case OK: {
-                                    sendResult.getIos().setSent(sendResult.getIos().getSent() + 1);
-                                    pushMessageObject.setStatus(PushMessageEntity.Status.SENT);
-                                    pushMessageDAO.save(pushMessageObject);
-                                    break;
+                            try {
+                                switch (result) {
+                                    case OK: {
+                                        sendResult.getIos().setSent(sendResult.getIos().getSent() + 1);
+                                        pushMessageObject.setStatus(PushMessageEntity.Status.SENT);
+                                        pushMessageDAO.save(pushMessageObject);
+                                        break;
+                                    }
+                                    case PENDING: {
+                                        sendResult.getIos().setPending(sendResult.getIos().getPending() + 1);
+                                        pushMessageObject.setStatus(PushMessageEntity.Status.PENDING);
+                                        pushMessageDAO.save(pushMessageObject);
+                                        break;
+                                    }
+                                    case FAILED: {
+                                        sendResult.getIos().setFailed(sendResult.getIos().getFailed() + 1);
+                                        pushMessageObject.setStatus(PushMessageEntity.Status.FAILED);
+                                        pushMessageDAO.save(pushMessageObject);
+                                        break;
+                                    }
+                                    case FAILED_DELETE: {
+                                        sendResult.getIos().setFailed(sendResult.getIos().getFailed() + 1);
+                                        pushMessageObject.setStatus(PushMessageEntity.Status.FAILED);
+                                        pushMessageDAO.save(pushMessageObject);
+                                        pushDeviceRepository.delete(device);
+                                        break;
+                                    }
                                 }
-                                case PENDING: {
-                                    sendResult.getIos().setPending(sendResult.getIos().getPending() + 1);
-                                    pushMessageObject.setStatus(PushMessageEntity.Status.PENDING);
-                                    pushMessageDAO.save(pushMessageObject);
-                                    break;
-                                }
-                                case FAILED: {
-                                    sendResult.getIos().setFailed(sendResult.getIos().getFailed() + 1);
-                                    pushMessageObject.setStatus(PushMessageEntity.Status.FAILED);
-                                    pushMessageDAO.save(pushMessageObject);
-                                    break;
-                                }
-                                case FAILED_DELETE: {
-                                    sendResult.getIos().setFailed(sendResult.getIos().getFailed() + 1);
-                                    pushMessageObject.setStatus(PushMessageEntity.Status.FAILED);
-                                    pushMessageDAO.save(pushMessageObject);
-                                    pushDeviceRepository.delete(device);
-                                    break;
-                                }
+                                sendResult.getIos().setTotal(sendResult.getIos().getTotal() + 1);
+                            } finally {
+                                phaser.arriveAndDeregister();
                             }
-                            sendResult.getIos().setTotal(sendResult.getIos().getTotal() + 1);
-                            phaser.arriveAndDeregister();
                         });
                     } else if (platform.equals(PushDeviceRegistrationEntity.Platform.Android)) {
                         final String token = device.getPushToken();
                         sendMessageToAndroid(pushClient.getFcmClient(), pushMessage.getBody(), pushMessage.getAttributes(), token, (sendingResult, contextData) -> {
-                            switch (sendingResult) {
-                                case OK: {
-                                    sendResult.getAndroid().setSent(sendResult.getAndroid().getSent() + 1);
-                                    pushMessageObject.setStatus(PushMessageEntity.Status.SENT);
-                                    pushMessageDAO.save(pushMessageObject);
-                                    updateFcmTokenIfNeeded(appId, token, contextData);
-                                    break;
+                            try {
+                                switch (sendingResult) {
+                                    case OK: {
+                                        sendResult.getAndroid().setSent(sendResult.getAndroid().getSent() + 1);
+                                        pushMessageObject.setStatus(PushMessageEntity.Status.SENT);
+                                        pushMessageDAO.save(pushMessageObject);
+                                        updateFcmTokenIfNeeded(appId, token, contextData);
+                                        break;
+                                    }
+                                    case PENDING: {
+                                        sendResult.getAndroid().setPending(sendResult.getAndroid().getPending() + 1);
+                                        pushMessageObject.setStatus(PushMessageEntity.Status.PENDING);
+                                        pushMessageDAO.save(pushMessageObject);
+                                        break;
+                                    }
+                                    case FAILED: {
+                                        sendResult.getAndroid().setFailed(sendResult.getAndroid().getFailed() + 1);
+                                        pushMessageObject.setStatus(PushMessageEntity.Status.FAILED);
+                                        pushMessageDAO.save(pushMessageObject);
+                                        break;
+                                    }
+                                    case FAILED_DELETE: {
+                                        sendResult.getAndroid().setFailed(sendResult.getAndroid().getFailed() + 1);
+                                        pushMessageObject.setStatus(PushMessageEntity.Status.FAILED);
+                                        pushMessageDAO.save(pushMessageObject);
+                                        pushDeviceRepository.delete(device);
+                                        break;
+                                    }
                                 }
-                                case PENDING: {
-                                    sendResult.getAndroid().setPending(sendResult.getAndroid().getPending() + 1);
-                                    pushMessageObject.setStatus(PushMessageEntity.Status.PENDING);
-                                    pushMessageDAO.save(pushMessageObject);
-                                    break;
-                                }
-                                case FAILED: {
-                                    sendResult.getAndroid().setFailed(sendResult.getAndroid().getFailed() + 1);
-                                    pushMessageObject.setStatus(PushMessageEntity.Status.FAILED);
-                                    pushMessageDAO.save(pushMessageObject);
-                                    break;
-                                }
-                                case FAILED_DELETE: {
-                                    sendResult.getAndroid().setFailed(sendResult.getAndroid().getFailed() + 1);
-                                    pushMessageObject.setStatus(PushMessageEntity.Status.FAILED);
-                                    pushMessageDAO.save(pushMessageObject);
-                                    pushDeviceRepository.delete(device);
-                                    break;
-                                }
+                                sendResult.getAndroid().setTotal(sendResult.getAndroid().getTotal() + 1);
+                            } finally {
+                                phaser.arriveAndDeregister();
                             }
-                            sendResult.getAndroid().setTotal(sendResult.getAndroid().getTotal() + 1);
-                            phaser.arriveAndDeregister();
                         });
                     }
                 }

--- a/powerauth-push-server/src/main/java/io/getlime/push/service/PushMessageSenderService.java
+++ b/powerauth-push-server/src/main/java/io/getlime/push/service/PushMessageSenderService.java
@@ -387,7 +387,7 @@ public class PushMessageSenderService {
         try {
             future = fcmClient.exchange(request);
         } catch (Throwable t) { // In case of some catastrophic error
-            Logger.getLogger(PushMessageSenderService.class.getName()).log(Level.SEVERE, "Notification sending failed: " + t.getLocalizedMessage(), t);
+            Logger.getLogger(PushMessageSenderService.class.getName()).log(Level.SEVERE, "Notification sending failed: " + t.getMessage(), t);
             callback.didFinishSendingMessage(PushSendingCallback.Result.FAILED, null);
             return;
         }
@@ -396,7 +396,7 @@ public class PushMessageSenderService {
 
             @Override
             public void onFailure(Throwable throwable) {
-                Logger.getLogger(PushMessageSenderService.class.getName()).log(Level.SEVERE, "Notification rejected by the FCM gateway: " + throwable.getLocalizedMessage(), throwable);
+                Logger.getLogger(PushMessageSenderService.class.getName()).log(Level.SEVERE, "Notification rejected by the FCM gateway: " + throwable.getMessage(), throwable);
                 callback.didFinishSendingMessage(PushSendingCallback.Result.FAILED, null);
             }
 

--- a/powerauth-push-server/src/main/java/io/getlime/push/service/fcm/FcmClient.java
+++ b/powerauth-push-server/src/main/java/io/getlime/push/service/fcm/FcmClient.java
@@ -30,6 +30,7 @@ import org.springframework.http.*;
 import org.springframework.http.client.HttpComponentsAsyncClientHttpRequestFactory;
 import org.springframework.util.concurrent.ListenableFuture;
 import org.springframework.web.client.AsyncRestTemplate;
+import org.springframework.web.client.RestClientException;
 
 /**
  * FCM server client
@@ -87,8 +88,9 @@ public class FcmClient {
      * Send given FCM request to the server.
      * @param request FCM data request.
      * @return Listenable future for result callbacks.
+     * @throws RestClientException In case network error occurs.
      */
-    public ListenableFuture<ResponseEntity<FcmSendResponse>> exchange(FcmSendRequest request) {
+    public ListenableFuture<ResponseEntity<FcmSendResponse>> exchange(FcmSendRequest request) throws RestClientException {
         HttpEntity<FcmSendRequest> entity = new HttpEntity<>(request, headers);
         return restTemplate.exchange(fcm_url, HttpMethod.POST, entity, FcmSendResponse.class);
     }


### PR DESCRIPTION
There is still some small room for improvement in the synchronization aspect. There might be unexpected and awkward runtime exceptions thrown while sending push notification (out of memory issue, etc.) and in this case, the phaser is not deregistered again and will cause server to hang.

However, the current handling should be generic enough to account for:

- Database errors.
- Errors during network communication that is done when sending push notifications to APNS/FCM.