### PR TITLE
Fix #121: Warning during startup due to sequence generator names

### DIFF
--- a/docs/sql/mysql/create_push_server_schema.sql
+++ b/docs/sql/mysql/create_push_server_schema.sql
@@ -1,5 +1,5 @@
 CREATE TABLE `push_app_credentials` (
-  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `id` bigint(20) NOT NULL,
   `app_id` bigint(20) NOT NULL,
   `ios_private_key` blob DEFAULT NULL,
   `ios_team_id` varchar(255) DEFAULT NULL,
@@ -12,7 +12,7 @@ CREATE TABLE `push_app_credentials` (
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
 
 CREATE TABLE `push_device_registration` (
-  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `id` bigint(20) NOT NULL,
   `activation_id` varchar(37) DEFAULT NULL,
   `user_id` varchar(255) DEFAULT NULL,
   `app_id` bigint(20) NOT NULL,
@@ -29,7 +29,7 @@ CREATE TABLE `push_device_registration` (
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
 
 CREATE TABLE `push_message` (
-  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `id` bigint(20) NOT NULL,
   `device_registration_id` bigint(20) NOT NULL,
   `user_id` varchar(255) DEFAULT NULL,
   `activation_id` varchar(37) DEFAULT NULL,
@@ -44,7 +44,7 @@ CREATE TABLE `push_message` (
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
 
 CREATE TABLE push_campaign (
-  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `id` bigint(20) NOT NULL,
   `app_id` bigint(20) NOT NULL,
   `message` text NOT NULL,
   `is_sent` int(1) DEFAULT 0,
@@ -55,10 +55,31 @@ CREATE TABLE push_campaign (
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
 
 CREATE TABLE push_campaign_user (
-  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `id` bigint(20) NOT NULL,
   `campaign_id` bigint(20) NOT NULL,
   `user_id` varchar(255) NOT NULL,
   `timestamp_created` DATETIME NOT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
 
+# Sequence tables for GenerationType.TABLE style id generators used by default in Hibernate 5 for MySQL
+CREATE TABLE push_credentials_seq (
+  next_val INTEGER NOT NULL
+);
+CREATE TABLE push_device_registration_seq (
+  next_val INTEGER NOT NULL
+);
+CREATE TABLE push_message_seq (
+  next_val INTEGER NOT NULL
+);
+CREATE TABLE push_campaign_seq (
+  next_val INTEGER NOT NULL
+);
+CREATE TABLE push_campaign_user_seq (
+  next_val INTEGER NOT NULL
+);
+INSERT INTO push_credentials_seq values (1);
+INSERT INTO push_device_registration_seq values (1);
+INSERT INTO push_message_seq values (1);
+INSERT INTO push_campaign_seq values (1);
+INSERT INTO push_campaign_user_seq values (1);

--- a/powerauth-push-server/src/main/java/io/getlime/push/repository/model/AppCredentialsEntity.java
+++ b/powerauth-push-server/src/main/java/io/getlime/push/repository/model/AppCredentialsEntity.java
@@ -16,8 +16,6 @@
 
 package io.getlime.push.repository.model;
 
-import org.hibernate.annotations.GenericGenerator;
-
 import javax.persistence.*;
 import java.io.Serializable;
 
@@ -35,8 +33,6 @@ public class AppCredentialsEntity implements Serializable {
     @Column(name = "id")
     @SequenceGenerator(name = "push_app_credentials", sequenceName = "push_credentials_seq")
     @GeneratedValue(strategy = GenerationType.AUTO, generator = "push_app_credentials")
-    // Native strategy is set to support multiple databases. Default native generator for Oracle is SEQUENCE, for MySQL the default is AUTO_INCREMENT.
-    @GenericGenerator(name = "push_app_credentials", strategy = "native")
     private Long id;
 
     @Column(name = "app_id", nullable = false, updatable = false)

--- a/powerauth-push-server/src/main/java/io/getlime/push/repository/model/PushCampaignEntity.java
+++ b/powerauth-push-server/src/main/java/io/getlime/push/repository/model/PushCampaignEntity.java
@@ -16,8 +16,6 @@
 
 package io.getlime.push.repository.model;
 
-import org.hibernate.annotations.GenericGenerator;
-
 import javax.persistence.*;
 import java.io.Serializable;
 import java.util.Date;
@@ -35,8 +33,6 @@ public class PushCampaignEntity implements Serializable {
     @Column(name = "id")
     @SequenceGenerator(name = "push_campaign", sequenceName = "push_campaign_seq")
     @GeneratedValue(strategy = GenerationType.AUTO, generator = "push_campaign")
-    // Native strategy is set to support multiple databases. Default native generator for Oracle is SEQUENCE, for MySQL the default is AUTO_INCREMENT.
-    @GenericGenerator(name = "push_campaign", strategy = "native")
     private Long id;
 
     @Column(name = "app_id", nullable = false, updatable = false)

--- a/powerauth-push-server/src/main/java/io/getlime/push/repository/model/PushCampaignUserEntity.java
+++ b/powerauth-push-server/src/main/java/io/getlime/push/repository/model/PushCampaignUserEntity.java
@@ -35,8 +35,6 @@ public class PushCampaignUserEntity implements Serializable {
     @Column(name = "id")
     @SequenceGenerator(name = "push_campaign_user", sequenceName = "push_campaign_user_seq")
     @GeneratedValue(strategy = GenerationType.AUTO, generator = "push_campaign_user")
-    // Native strategy is set to support multiple databases. Default native generator for Oracle is SEQUENCE, for MySQL the default is AUTO_INCREMENT.
-    @GenericGenerator(name = "push_campaign_user", strategy = "native")
     private Long id;
 
     @Column(name = "campaign_id", nullable = false, updatable = false)

--- a/powerauth-push-server/src/main/java/io/getlime/push/repository/model/PushDeviceRegistrationEntity.java
+++ b/powerauth-push-server/src/main/java/io/getlime/push/repository/model/PushDeviceRegistrationEntity.java
@@ -16,8 +16,6 @@
 
 package io.getlime.push.repository.model;
 
-import org.hibernate.annotations.GenericGenerator;
-
 import javax.persistence.*;
 import java.io.Serializable;
 import java.util.Date;
@@ -42,8 +40,6 @@ public class PushDeviceRegistrationEntity implements Serializable {
     @Column(name = "id")
     @SequenceGenerator(name = "push_device_registration", sequenceName = "push_device_registration_seq")
     @GeneratedValue(strategy = GenerationType.AUTO, generator = "push_device_registration")
-    // Native strategy is set to support multiple databases. Default native generator for Oracle is SEQUENCE, for MySQL the default is AUTO_INCREMENT.
-    @GenericGenerator(name = "push_device_registration", strategy = "native")
     private Long id;
 
     @Column(name = "activation_id")

--- a/powerauth-push-server/src/main/java/io/getlime/push/repository/model/PushMessageEntity.java
+++ b/powerauth-push-server/src/main/java/io/getlime/push/repository/model/PushMessageEntity.java
@@ -17,7 +17,6 @@
 package io.getlime.push.repository.model;
 
 import io.getlime.push.repository.converter.PushMessageStatusConverter;
-import org.hibernate.annotations.GenericGenerator;
 
 import javax.persistence.*;
 import java.io.Serializable;
@@ -52,8 +51,6 @@ public class PushMessageEntity implements Serializable {
     @Column(name = "id")
     @SequenceGenerator(name = "push_message", sequenceName = "push_message_seq")
     @GeneratedValue(strategy = GenerationType.AUTO, generator = "push_message")
-    // Native strategy is set to support multiple databases. Default native generator for Oracle is SEQUENCE, for MySQL the default is AUTO_INCREMENT.
-    @GenericGenerator(name = "push_message", strategy = "native")
     private Long id;
 
     @Column(name = "device_registration_id", nullable = false, updatable = false)


### PR DESCRIPTION
Change description:

* Removed `@GenericGenerator` to avoid ID generator name conflict, `@SequenceGenerator` is used in all production databases
* ID generation strategy switched to `TABLE` for MySQL (due to changed default in Hibernate 5, MySQL is only used for development, thus performance issues related to row level database locking do not matter)